### PR TITLE
Fix bug and add # to comment

### DIFF
--- a/python/Huffman_Algorithm.py
+++ b/python/Huffman_Algorithm.py
@@ -1,4 +1,4 @@
-hon Code for Huffman Coding
+# hon Code for Huffman Coding
 from collections import Counter
 
 


### PR DESCRIPTION
This commit fixes a bug in the python/Huffman_Algorithm.py  where a comment was missing a #. This caused the comment to be interpreted as code, which resulted in the bug.

I have added the # to the comment so that it is now interpreted as a comment. I have also fixed the bug that was being caused by the missing #.